### PR TITLE
修复load_vector()出错bug

### DIFF
--- a/server/rag/v1/tool/load_file.py
+++ b/server/rag/v1/tool/load_file.py
@@ -91,7 +91,7 @@ class ReadFiles:
                 chunk_text.append(curr_chunk)
             elif curr_len + line_len <= token_len:
                 # 当前片段长度未超过限制时，继续累加
-                curr_chunk += line + '\n'
+                curr_chunk += line + ' '
                 curr_len += line_len + 1
             else:
                 chunk_text.append(curr_chunk)  # 保存当前片段


### PR DESCRIPTION
bug原因:片段分割时会新增换行符到文本中导致load_vector()读取出错